### PR TITLE
Saves to extensionless path

### DIFF
--- a/lib/rszr/image.rb
+++ b/lib/rszr/image.rb
@@ -271,7 +271,11 @@ module Rszr
     end
 
     def format_from_filename(path)
-      File.extname(path)[1..-1].to_s.downcase
+      extension = File.extname(path)[1..-1]
+
+      return if extension.nil?
+
+      extension.to_s.downcase
     end
     
     def ensure_path_is_writable(path)

--- a/spec/rszr_spec.rb
+++ b/spec/rszr_spec.rb
@@ -189,6 +189,16 @@ RSpec.describe 'Rszr' do
         expect(resized_file.exist?).to be(true)
       end
     end
+
+    it 'saves images when given path does not have extension' do
+      Dir.mktmpdir do |dir|
+        resized_file = Pathname.new(File.join(dir, 'resized_jpg'))
+        resized_file.unlink if resized_file.exist?
+        expect(resized_file.exist?).to be(false)
+        expect(@image.save(resized_file.to_s)).to be(true)
+        expect(resized_file.exist?).to be(true)
+      end
+    end
     
     it 'raises save errors' do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
`format_from_filename`  was returning empty string when path has no extension. This was breaking following logic in `Rszr::Image#save`:

```ruby
 format ||= format_from_filename(path) || self.format || 'jpg'
 ```

This PR changes `format_from_filename` to return `nil` if path does not have extension.